### PR TITLE
Use unicode-display_width gem

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,10 +287,6 @@ x*******x*******x*******x
 x*******x*******x*******x
 ~~~
 
-## :memo: 注意事項
-* gem のバージョンが 2.0.1 以下だと unicode gem でエラーが発生するケースがあるようです。
-  その場合は gem を 2.0.2 以上に Update してください。
-
 ## :two_men_holding_hands: Contributing :two_women_holding_hands:
 
 1. Fork it ( https://github.com/tbpgr/kosi/fork )

--- a/kosi.gemspec
+++ b/kosi.gemspec
@@ -18,7 +18,10 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']
 
-  spec.add_runtime_dependency 'unicode', '>= 0.4.4'
+  spec.required_ruby_version = '~> 2.0'
+
+  spec.add_runtime_dependency 'unicode-display_width', '~> 1.0'
+  spec.add_runtime_dependency 'unicode-emoji', '~> 0.9'
 
   spec.add_development_dependency 'bundler', '~> 1.15.3'
   spec.add_development_dependency 'rake'

--- a/kosi.gemspec
+++ b/kosi.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'unicode-display_width', '~> 1.0'
   spec.add_runtime_dependency 'unicode-emoji', '~> 0.9'
 
-  spec.add_development_dependency 'bundler', '~> 1.15.3'
+  spec.add_development_dependency 'bundler', '~> 1.15'
   spec.add_development_dependency 'rake'
   spec.add_development_dependency 'rspec', '~> 3.6.0'
   spec.add_development_dependency 'simplecov', '~> 0.14.1'

--- a/lib/table.rb
+++ b/lib/table.rb
@@ -1,7 +1,8 @@
 # encoding: utf-8
 require 'kosi'
 require 'kosi/validators'
-require 'unicode'
+require 'unicode/display_width/no_string_ext'
+require 'unicode/emoji'
 
 # TableFormat for Terminal(Use Japanese Charactors)
 module Kosi
@@ -60,7 +61,7 @@ module Kosi
 
     def ascii1_other2_size(column)
       column.split('').reduce(0) do |a, e|
-        a += Unicode.width(e)
+        a += Unicode::DisplayWidth.of(e, 1, {}, emoji: true)
         a
       end
     end


### PR DESCRIPTION
## 変更点
unicode gem の代わりに [unicode-display_width](https://github.com/janlelis/unicode-display_width) と [unicode-emoji](https://github.com/janlelis/unicode-emoji) を使うようにしました。最近の Unicode で追加された絵文字の幅を正しく判定できるようになります。