### PR TITLE
bump up required_ruby_version and unocode-emoji

### DIFF
--- a/kosi.gemspec
+++ b/kosi.gemspec
@@ -18,10 +18,10 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']
 
-  spec.required_ruby_version = '~> 2.0'
+  spec.required_ruby_version = '~> 2.3'
 
   spec.add_runtime_dependency 'unicode-display_width', '~> 1.0'
-  spec.add_runtime_dependency 'unicode-emoji', '~> 0.9'
+  spec.add_runtime_dependency 'unicode-emoji', '~> 1.1'
   spec.add_development_dependency 'bundler', '~> 1.15'
   spec.add_development_dependency 'rake'
   spec.add_development_dependency 'rspec', '~> 3.6.0'


### PR DESCRIPTION
```
NOTE: Gem.gunzip is deprecated; use Gem::Util.gunzip instead. It will be removed on or after 2018-12-01.
```

上記 deprecation warning が出ているため、unicode-emoji のバージョンを更新しました。
unicode-emoji がサポートしている Ruby の都合上、下限が 2.0 から 2.3 に引き上がってしまいます。

問題ないようでしたら取り込んで頂けると助かります。