### PR TITLE
Add Ruby support 2.6 / 2.7 / 3.0 / 3.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,10 @@ before_install:
   - gem update bundler
   - gem --version
 rvm:
-  - 2.3.4
-  - 2.4.1
-  - 2.5.0
+  - 2.3.8
+  - 2.4.10
+  - 2.5.9
+  - 2.6.10
+  - 2.7.6
+  - 3.0.4
+  - 3.1.2

--- a/kosi.gemspec
+++ b/kosi.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']
 
-  spec.required_ruby_version = '~> 2.3'
+  spec.required_ruby_version = '>= 2.3'
 
   spec.add_runtime_dependency 'unicode-display_width'
   spec.add_runtime_dependency 'unicode-emoji'

--- a/kosi.gemspec
+++ b/kosi.gemspec
@@ -20,9 +20,9 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = '~> 2.3'
 
-  spec.add_runtime_dependency 'unicode-display_width', '~> 1.0'
-  spec.add_runtime_dependency 'unicode-emoji', '~> 1.1'
-  spec.add_development_dependency 'bundler', '~> 1.15'
+  spec.add_runtime_dependency 'unicode-display_width'
+  spec.add_runtime_dependency 'unicode-emoji'
+  spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'rake'
   spec.add_development_dependency 'rspec', '~> 3.6.0'
   spec.add_development_dependency 'simplecov', '~> 0.14.1'


### PR DESCRIPTION
Ruby 3以上に上げる際に、unicode-emojiがv 1.1.0に固定されていると上がらないため、unicode-emojiのバージョン固定を外す対応をしました。