### PR TITLE
Fix unicode-display_width Warning on require

### DIFF
--- a/lib/table.rb
+++ b/lib/table.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require 'kosi'
 require 'kosi/validators'
-require 'unicode/display_width/no_string_ext'
+require 'unicode/display_width'
 require 'unicode/emoji'
 
 # TableFormat for Terminal(Use Japanese Characters)


### PR DESCRIPTION
janlelis/unicode-display_width has deprecated `require "unicode/display_width/no_string_ext"` since v2.0.0.

I removed `no_string_ext` so that warnings are not output.

ref: https://github.com/janlelis/unicode-display_width/blob/ef4731c2ed9b1e884d6cff4d3ea12e88a6b8c148/CHANGELOG.md#200pre1


### example

before

```
(kosi): bundle exec rspec spec/table_spec.rb
[Coveralls] Set up the SimpleCov formatter.
[Coveralls] Using SimpleCov's default settings.
You are loading 'unicode-display_width/no_string_ext'
Beginning with version 2.0, this is not necessary anymore
You can just require 'unicode-display_width' now and no
string extension will be loaded
Run options: include {:focus=>true}

All examples were filtered out; ignoring {:focus=>true}
.......

Finished in 0.01178 seconds (files took 0.45498 seconds to load)
7 examples, 0 failures
```

after

```
(kosi): bundle exec rspec spec/table_spec.rb
[Coveralls] Set up the SimpleCov formatter.
[Coveralls] Using SimpleCov's default settings.
Run options: include {:focus=>true}

All examples were filtered out; ignoring {:focus=>true}
.......

Finished in 0.01295 seconds (files took 0.15436 seconds to load)
7 examples, 0 failures
```