### PR TITLE
Bump up version number to 1.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+## v1.3.0
+2022/10/20
+
+### Update Feature
+* Ruby2.6, 2.7, 3.0, 3.1をサポート
+    * https://github.com/tbpgr/kosi/pull/6
+* janlelis/unicode-display_widthの警告対応
+    * https://github.com/tbpgr/kosi/pull/7
+
 ## v1.2.0
 2018/01/18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## v1.2.0
+2018/01/18
+
+### Update Feature
+* Ruby2.0, 2.1, 2.2のサポートを終了
+    * https://github.com/tbpgr/kosi/commit/8216113c810d8170743c2fe27e921870d62e9d71
+
 ## v.1.1.0
 2018/01/08
 

--- a/lib/kosi/version.rb
+++ b/lib/kosi/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 # TableFormat for Terminal(Use Japanese Characters)
 module Kosi
-  VERSION = '1.2.0'
+  VERSION = '1.3.0'
 end


### PR DESCRIPTION
Ruby3.0以降に対応したバージョンが欲しかったので、PRを送らせていただきました。
CHANGELOGに直近の変更内容を追加しました。
lib/kosi/version.rbの`VERSION`の値を変更もあわせて行っています。